### PR TITLE
feat: basic input 컴포넌트 구현(#1)

### DIFF
--- a/src/app/(page)/sk/page.tsx
+++ b/src/app/(page)/sk/page.tsx
@@ -1,7 +1,14 @@
+import Input1 from "@components/Input/Input1";
 const sk = () => {
   return (
     <>
-      <h1>sk Component</h1>
+      <Input1 size="xs" placeholder="extra small size" />
+      <Input1 size="sm" placeholder="small size" />
+      <Input1 size="md" placeholder="medium size" />
+      <Input1 size="lg" placeholder="large size" />
+      <Input1 size="xl" placeholder="Extra large size" />
+      <Input1 size="md" variant="filled" placeholder="Filled input" />
+      <Input1 size="md" variant="outlined" placeholder="Outlined input" />
     </>
   );
 };

--- a/src/components/Input/Input1.tsx
+++ b/src/components/Input/Input1.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+
+type InputSize = "xs" | "sm" | "md" | "lg" | "xl";
+type InputVariant = "outlined" | "filled";
+
+interface InputProps {
+  size?: InputSize;
+  variant?: InputVariant;
+  placeholder?: string;
+  value?: string;
+  onChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const sizeClasses = {
+  xs: "py-1 px-2 text-xs",
+  sm: "py-1.5 px-3 text-sm",
+  md: "py-2 px-4 text-base",
+  lg: "py-3 px-4 text-lg",
+  xl: "py-4 px-5 text-lg",
+};
+
+const variantClasses = {
+  outlined: "border border-Basic bg-white",
+  filled: "bg-Basic text-white placeholder-white border-none",
+};
+
+const Input1: React.FC<InputProps> = ({
+  size = "md",
+  variant = "outlined",
+  placeholder,
+  value,
+  onChange,
+}) => {
+  return (
+    <input
+      type="text"
+      className={`focus:border-basic rounded-md ${variantClasses[variant]} ${sizeClasses[size]} md:w-1/4 lg:w-2/3 xl:w-3/5`}
+      placeholder={placeholder}
+      value={value}
+      onChange={onChange}
+    />
+  );
+};
+
+export default Input1;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,6 +13,15 @@ const config: Config = {
         "gradient-conic":
           "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
       },
+      colors: {
+        Basic: "#9AC5E5",
+        Primary: "#7AA7FF",
+        gray: "#DCDCDD",
+        Secondary: "#C294F0",
+        Success: "#7EEFAF",
+        Warning: "#EDCE7B",
+        Danger: "#FF7676",
+      },
     },
   },
   plugins: [],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "baseUrl": "./src",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
@@ -18,7 +19,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"], // src 폴더 내 모든 파일을 @로 접근 가능
+      "@components/*": ["components/*"], // src/components 폴더
+      "@page/*": ["page/*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
## 🛰️ Issue Number
 - closed: #1 
## 🪐 작업 내용
### 1. 사이즈별 베이직 인풋박스 구현
- 사이즈 옵션에 따른 인풋 박스 (`xs`, `sm`, `md`, `lg`, `xl`)
  
### 2. Fill 속성별 인풋박스 구현
  - `outlined`: 외곽선이 있는 기본 스타일
  - `filled`: 배경이 채워진 스타일로, 텍스트와 placeholder가 흰색으로 설정되었습니다.

### 3. Input 컴포넌트 Props 요소들
- `size`: 인풋의 크기를 결정하는 요소 (`xs`, `sm`, `md`, `lg`, `xl`)
- `variant`: 인풋의 스타일을 결정하는 요소 (`outlined`, `filled`)
- `placeholder`: 인풋 필드의 placeholder 텍스트
- `value`: 인풋 필드의 현재 값
- `onChange`: 인풋 필드의 값이 변경될 때 호출되는 함수

## 📷스크린샷
<img width="908" alt="스크린샷 2024-08-12 17 43 03" src="https://github.com/user-attachments/assets/9df832f4-87df-4214-bdd3-b0feb9000544">
