### PR TITLE
feat: 체크박스 컴포넌트의 체크박스 스타일 추가

### DIFF
--- a/src/app/(page)/dw/page.tsx
+++ b/src/app/(page)/dw/page.tsx
@@ -91,6 +91,78 @@ const dw = () => {
           <CheckBox description="Pink CheckBox" color="pink" />
           <CheckBox description="Basic CheckBox" color="basic" />
         </div>
+        <h2 className="ml-4 text-2xl">체크박스의 컬러2</h2>
+        <div className="ml-4 flex space-x-5">
+          <CheckBox
+            description="Primary Border CheckBox"
+            color="primary"
+            variant="border"
+          />
+          <CheckBox
+            description="Secondary Border CheckBox"
+            color="secondary"
+            variant="border"
+          />
+          <CheckBox
+            description="Success Border CheckBox"
+            color="success"
+            variant="border"
+          />
+          <CheckBox
+            description="Warning Border CheckBox"
+            color="warning"
+            variant="border"
+          />
+          <CheckBox
+            description="Danger Border CheckBox"
+            color="danger"
+            variant="border"
+          />
+        </div>
+        <div className="ml-4 flex space-x-5">
+          <CheckBox
+            description="Red Border CheckBox"
+            color="red"
+            variant="border"
+          />
+          <CheckBox
+            description="Orange Border CheckBox"
+            color="orange"
+            variant="border"
+          />
+          <CheckBox
+            description="Yellow Border CheckBox"
+            color="yellow"
+            variant="border"
+          />
+          <CheckBox
+            description="Green Border CheckBox"
+            color="green"
+            variant="border"
+          />
+        </div>
+        <div className="ml-4 flex space-x-5">
+          <CheckBox
+            description="Blue Border CheckBox"
+            color="blue"
+            variant="border"
+          />
+          <CheckBox
+            description="Purple Border CheckBox"
+            color="purple"
+            variant="border"
+          />
+          <CheckBox
+            description="Pink Border CheckBox"
+            color="pink"
+            variant="border"
+          />
+          <CheckBox
+            description="Basic Border CheckBox"
+            color="basic"
+            variant="border"
+          />
+        </div>
       </div>
     </>
   );

--- a/src/components/CheckBox/CheckBox.tsx
+++ b/src/components/CheckBox/CheckBox.tsx
@@ -19,6 +19,7 @@ type CheckBoxProps = {
     | "purple"
     | "pink"
     | "basic";
+  variant?: "solid" | "border";
 } & React.InputHTMLAttributes<HTMLInputElement>;
 
 const CheckBox: React.FC<CheckBoxProps> = ({
@@ -28,6 +29,7 @@ const CheckBox: React.FC<CheckBoxProps> = ({
   description,
   color = "basic",
   boxSize = "medium",
+  variant = "solid",
   ...rest
 }) => {
   const [checkId, setCheckId] = useState<string | undefined>(undefined);
@@ -74,6 +76,39 @@ const CheckBox: React.FC<CheckBoxProps> = ({
     pink: "checked:!bg-Pink checked:!border-Pink hover:!border-Pink",
     basic: "checked:!bg-Basic checked:!border-Basic hover:!border-Basic",
   };
+  const borderColors = {
+    primary:
+      "checked:bg-transparent checked:after:border-b-Primary checked:after:border-r-Primary checked:!border-Primary hover:!border-Primary",
+    secondary:
+      "checked:bg-transparent checked:after:border-b-Secondary checked:after:border-r-Secondary checked:!border-Secondary hover:!border-Secondary",
+    success:
+      "checked:bg-transparent checked:after:border-b-Success checked:after:border-r-Success checked:!border-Success hover:!border-Success",
+    warning:
+      "checked:bg-transparent checked:after:border-b-Warning checked:after:border-r-Warning checked:!border-Warning hover:!border-Warning",
+    danger:
+      "checked:bg-transparent checked:after:border-b-Danger checked:after:border-r-Danger checked:!border-Danger hover:!border-Danger",
+    red: "checked:bg-transparent checked:after:border-b-Red checked:after:border-r-Red checked:!border-Red hover:!border-Red",
+    orange:
+      "checked:bg-transparent checked:after:border-b-Orange checked:after:border-r-Orange checked:!border-Orange hover:!border-Orange",
+    yellow:
+      "checked:bg-transparent checked:after:border-b-Yellow checked:after:border-r-Yellow checked:!border-Yellow hover:!border-Yellow",
+    green:
+      "checked:bg-transparent checked:after:border-b-Green checked:after:border-r-Green checked:!border-Green hover:!border-Green",
+    blue: "checked:bg-transparent checked:after:border-b-Blue checked:after:border-r-Blue checked:!border-Blue hover:!border-Blue",
+    purple:
+      "checked:bg-transparent checked:after:border-b-Purple checked:after:border-r-Purple checked:!border-Purple hover:!border-Purple",
+    pink: "checked:bg-transparent checked:after:border-b-Pink checked:after:border-r-Pink checked:!border-Pink hover:!border-Pink",
+    basic:
+      "checked:bg-transparent checked:after:border-b-Basic checked:after:border-r-Basic checked:!border-Basic hover:!border-Basic",
+  };
+
+  let ChckBoxVariant = "";
+
+  if (variant === "solid") {
+    ChckBoxVariant = `${colors[color]}`;
+  } else if (variant === "border") {
+    ChckBoxVariant = `${borderColors[color]}`;
+  }
 
   const basicCheckBox =
     "relative aspect-square h-5 w-5 cursor-pointer !appearance-none rounded border border-gray bg-white !outline-none !ring-0 !ring-offset-0 transition-all duration-300 ease-in-out after:absolute after:left-[50%] after:top-[40%] after:h-[53%] after:w-[35%] after:-translate-x-2/4 after:-translate-y-2/4 after:rotate-[25deg] after:border-b-[0.20em] after:border-r-[0.20em] after:border-b-white after:border-r-white after:transition-all after:duration-200 after:ease-linear checked:!border-Basic checked:bg-Basic checked:after:rotate-45 checked:after:opacity-100 hover:!border-Basic disabled:bg-slate-300 disabled:after:border-b-0 disabled:after:border-r-0";
@@ -83,7 +118,7 @@ const CheckBox: React.FC<CheckBoxProps> = ({
         type="checkbox"
         value={value}
         id={checkId}
-        className={`${basicCheckBox} ${checkBoxSize} ${colors[color]}`}
+        className={`${basicCheckBox} ${checkBoxSize} ${ChckBoxVariant} `}
         {...rest}
       />
       <label htmlFor={checkId} className={`ml-1 select-none ${checkBoxLabel}`}>


### PR DESCRIPTION
## 🛰️ Issue Number
 - closed: #42 
## 🪐 작업 내용
- 기존에는 배경이 채워진 체크박스 였으나 배경이 채워지지 않은 체크박스 스타일추가
- props는 solid(기본값)과 border
- 아래 코드 처럼 variant에 border로 하면 스크린샷의 체크박스의 컬러2 처럼 변경됨, 만약 사용자가 옵션을 따로 지정하지않으면 solid가 기본값이여서 체크박스의 컬러처럼 자동으로 적용됨

`  <CheckBox
            description="Primary Border CheckBox"
            color="primary"
            variant="border"
          />`
## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 📷스크린샷
PR과 관련된 UI 변경사항이 있다면, 스크린샷을 포함시키세요.
- 모션은 지난 PR(#36) 과 동일하므로 정적인 이미지로 올립니다. 
![image](https://github.com/user-attachments/assets/8d62e74d-994e-4cc5-ba3c-187e6943b6f4)
