### PR TITLE
feat: 기본 Toast 컴포넌트 구현

### DIFF
--- a/src/app/(page)/dw/page.tsx
+++ b/src/app/(page)/dw/page.tsx
@@ -204,7 +204,12 @@ const dw = () => {
         </div>
       </div>
       <div className="ml-3 mt-5 space-y-4">
-        <Toast isOpen={isToastOpen} onClose={onclickToastHandler(false)}>
+        <Toast
+          isOpen={isToastOpen}
+          size="medium"
+          onClose={onclickToastHandler(false)}
+          color="secondary"
+        >
           가입이 완료되었습니다.
         </Toast>
         <Button

--- a/src/app/(page)/dw/page.tsx
+++ b/src/app/(page)/dw/page.tsx
@@ -2,14 +2,20 @@
 import Button from "@components/Button/Button";
 import CheckBox from "@components/CheckBox/CheckBox";
 import Drawer from "@components/Drawer/Drawer";
+import Toast from "@components/Toast/Toast";
 import { useState } from "react";
 
 const dw = () => {
+  //Drawer 관련 코드
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const onclickDrawerHandler = (open: boolean) => () => {
     setIsDrawerOpen(open);
   };
-
+  //Toast 관련 코드
+  const [isToastOpen, setIsToastOpen] = useState(true);
+  const onclickToastHandler = (open: boolean) => () => {
+    setIsToastOpen(open);
+  };
   return (
     <>
       <h1>dw Component</h1>
@@ -170,6 +176,8 @@ const dw = () => {
             variant="border"
           />
         </div>
+      </div>
+      <div className="ml-3 mt-5 space-y-4">
         <div>
           <Drawer
             isOpen={isDrawerOpen}
@@ -182,7 +190,7 @@ const dw = () => {
               { name: "LongTitleTitleTitleTitleTitleTitle", path: "/Contact" },
             ]}
             logo="/componique_logo_full.svg"
-            postion="left"
+            postion="bottom"
             bgColor="basic"
           />
 
@@ -194,6 +202,18 @@ const dw = () => {
             Drawer Open Button
           </Button>
         </div>
+      </div>
+      <div className="ml-3 mt-5 space-y-4">
+        <Toast isOpen={isToastOpen} onClose={onclickToastHandler(false)}>
+          가입이 완료되었습니다.
+        </Toast>
+        <Button
+          variant="border"
+          color="success"
+          onClick={onclickToastHandler(true)}
+        >
+          Toast Open Button
+        </Button>
       </div>
     </>
   );

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -3,19 +3,21 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useEffect } from "react";
-import { Size } from "types/type";
+import { Color16, Size } from "types/type";
 type ToastProps = {
   size?: Size;
   isOpen?: boolean;
   postion?: "top" | "bottom" | "left" | "right";
   onClose?: () => void;
   children: React.ReactNode;
+  color?: Color16;
 };
 
 const Toast: React.FC<ToastProps> = ({
   children,
   isOpen = true,
   onClose,
+  color = "basic",
   size = "large",
   ...rest
 }) => {
@@ -33,6 +35,26 @@ const Toast: React.FC<ToastProps> = ({
 
   const ToastSize =
     size === "small" ? "w-4/12" : size === "medium" ? "w-6/12" : "w-full";
+
+  const bgColors = {
+    primary: "bg-Primary",
+    secondary: "bg-Secondary",
+    success: "bg-Success",
+    warning: "bg-Warning",
+    danger: "bg-Danger",
+    red: "bg-red-500",
+    orange: "bg-orange-500",
+    yellow: "bg-yellow-500",
+    green: "bg-green-500",
+    blue: "bg-blue-500",
+    purple: "bg-purple-500",
+    pink: "bg-pink-500",
+    basic: "bg-Basic",
+    white: "bg-white",
+    gray: "bg-gray",
+    black: "bg-black",
+  };
+
   const BasicToast =
     "min-w-md fixed left-1/2 top-10 w-11/12 -translate-x-1/2 -translate-y-1/2 transform";
   return (
@@ -43,7 +65,7 @@ const Toast: React.FC<ToastProps> = ({
         }`}
       >
         <div
-          className={`flex w-full items-center justify-between rounded-md bg-Basic p-4 ${ToastSize}`}
+          className={`flex w-full items-center justify-between rounded-md bg-Basic ${bgColors[color]} p-4 ${ToastSize}`}
           {...rest}
         >
           {children}

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -7,7 +7,17 @@ import { Color16, Size } from "types/type";
 type ToastProps = {
   size?: Size;
   isOpen?: boolean;
-  postion?: "top" | "bottom" | "left" | "right";
+  isClose?: boolean;
+  position?:
+    | "leftTop"
+    | "leftBottom"
+    | "rightTop"
+    | "rightBottom"
+    | "centerTop"
+    | "centerBottom"
+    | "left"
+    | "right"
+    | "center";
   onClose?: () => void;
   children: React.ReactNode;
   color?: Color16;
@@ -19,6 +29,7 @@ const Toast: React.FC<ToastProps> = ({
   onClose,
   color = "basic",
   size = "large",
+  position = "centerBottom",
   ...rest
 }) => {
   const [isToastOpen, setIsToastOpen] = useState(isOpen);
@@ -32,9 +43,14 @@ const Toast: React.FC<ToastProps> = ({
     setIsToastOpen(false);
     if (onClose) onClose();
   };
-
-  const ToastSize =
-    size === "small" ? "w-4/12" : size === "medium" ? "w-6/12" : "w-full";
+  const ToastSize = {
+    small:
+      "min-w-[200px] sm:min-w-[250px]  md:min-w-[390px] lg:min-w-[575px] xl:min-w-[650px]",
+    medium:
+      "min-w-[300px] sm:min-w-[375px]  md:min-w-[585px] lg:min-w-[863px] xl:min-w-[975px]",
+    large:
+      "min-w-[400px] sm:min-w-[500px]  md:min-w-[780px] lg:min-w-[1150px] xl:min-w-[1300px]",
+  };
 
   const bgColors = {
     primary: "bg-Primary",
@@ -54,24 +70,34 @@ const Toast: React.FC<ToastProps> = ({
     gray: "bg-gray",
     black: "bg-black",
   };
+  const ToastPosition = {
+    leftTop: "top-0 left-0",
+    centerTop: "top-0 left-1/2 -translate-x-1/2 ",
+    rightTop: "top-0  right-0 ",
+    left: "top-1/2 left-0 transform -translate-y-1/2 ",
+    center: "top-1/2 left-1/2 -translate-x-1/2 ",
+    right: "top-1/2 right-0 ",
+    leftBottom: "bottom-0 left-0 ",
+    centerBottom: "bottom-0 left-1/2 -translate-x-1/2 ",
+    rightBottom: "bottom-0 right-0  ",
+  };
 
-  const BasicToast =
-    "min-w-md fixed left-1/2 top-10 w-11/12 -translate-x-1/2 -translate-y-1/2 transform";
+  const BasicToast = "min-w-md   box-border fixed select-none ";
   return (
-    <>
+    <div>
       <section
-        className={`${BasicToast} ${
+        className={`${BasicToast} ${ToastPosition[position]} ${ToastSize[size]} ${
           isToastOpen ? "opacity-100" : "pointer-events-none opacity-0"
         }`}
       >
         <div
-          className={`flex w-full items-center justify-between rounded-md bg-Basic ${bgColors[color]} p-4 ${ToastSize}`}
+          className={`flex items-center justify-between rounded-md bg-Basic ${bgColors[color]} p-4`}
           {...rest}
         >
           {children}
 
           <button
-            className="group relative h-4 w-4 bg-transparent"
+            className="group relative ml-2 h-4 w-4 bg-transparent"
             onClick={onclickCloseHandler}
           >
             <span className="absolute left-1/2 top-1/2 block h-0.5 w-full -translate-x-1/2 -translate-y-1/2 rotate-45 transform bg-white"></span>
@@ -79,7 +105,7 @@ const Toast: React.FC<ToastProps> = ({
           </button>
         </div>
       </section>
-    </>
+    </div>
   );
 };
 export default Toast;

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -3,7 +3,9 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { useEffect } from "react";
+import { Size } from "types/type";
 type ToastProps = {
+  size?: Size;
   isOpen?: boolean;
   postion?: "top" | "bottom" | "left" | "right";
   onClose?: () => void;
@@ -14,6 +16,7 @@ const Toast: React.FC<ToastProps> = ({
   children,
   isOpen = true,
   onClose,
+  size = "large",
   ...rest
 }) => {
   const [isToastOpen, setIsToastOpen] = useState(isOpen);
@@ -27,15 +30,20 @@ const Toast: React.FC<ToastProps> = ({
     setIsToastOpen(false);
     if (onClose) onClose();
   };
+
+  const ToastSize =
+    size === "small" ? "w-4/12" : size === "medium" ? "w-6/12" : "w-full";
+  const BasicToast =
+    "min-w-md fixed left-1/2 top-10 w-11/12 -translate-x-1/2 -translate-y-1/2 transform";
   return (
     <>
       <section
-        className={`min-w-md fixed left-1/2 top-10 w-11/12 -translate-x-1/2 -translate-y-1/2 transform ${
+        className={`${BasicToast} ${
           isToastOpen ? "opacity-100" : "pointer-events-none opacity-0"
         }`}
       >
         <div
-          className="flex w-full items-center justify-between rounded-md bg-Basic p-4"
+          className={`flex w-full items-center justify-between rounded-md bg-Basic p-4 ${ToastSize}`}
           {...rest}
         >
           {children}

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { useEffect } from "react";
+type ToastProps = {
+  isOpen?: boolean;
+  postion?: "top" | "bottom" | "left" | "right";
+  onClose?: () => void;
+  children: React.ReactNode;
+};
+
+const Toast: React.FC<ToastProps> = ({
+  children,
+  isOpen = true,
+  onClose,
+  ...rest
+}) => {
+  const [isToastOpen, setIsToastOpen] = useState(isOpen);
+  const router = useRouter();
+
+  useEffect(() => {
+    setIsToastOpen(isOpen);
+  }, [isOpen]);
+
+  const onclickCloseHandler = () => {
+    setIsToastOpen(false);
+    if (onClose) onClose();
+  };
+  return (
+    <>
+      <section
+        className={`min-w-md fixed left-1/2 top-10 w-11/12 -translate-x-1/2 -translate-y-1/2 transform ${
+          isToastOpen ? "opacity-100" : "pointer-events-none opacity-0"
+        }`}
+      >
+        <div
+          className="flex w-full items-center justify-between rounded-md bg-Basic p-4"
+          {...rest}
+        >
+          {children}
+
+          <button
+            className="group relative h-4 w-4 bg-transparent"
+            onClick={onclickCloseHandler}
+          >
+            <span className="absolute left-1/2 top-1/2 block h-0.5 w-full -translate-x-1/2 -translate-y-1/2 rotate-45 transform bg-white"></span>
+            <span className="absolute left-1/2 top-1/2 block h-0.5 w-full -translate-x-1/2 -translate-y-1/2 -rotate-45 transform bg-white"></span>
+          </button>
+        </div>
+      </section>
+    </>
+  );
+};
+export default Toast;

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -10,3 +10,21 @@ export type Color =
   | "Warning"
   | "Danger"
   | "White";
+
+export type Color16 =
+  | "primary"
+  | "secondary"
+  | "success"
+  | "warning"
+  | "danger"
+  | "red"
+  | "orange"
+  | "yellow"
+  | "green"
+  | "blue"
+  | "purple"
+  | "pink"
+  | "basic"
+  | "white"
+  | "gray"
+  | "black";


### PR DESCRIPTION
## 🛰️ Issue Number
 - closed: #63 
## 🪐 작업 내용
 - 기본 Toast 를 구현했습니다. 닫기 버튼을 클릭하면 사라집니다
 - 현재는 Toast Open Button 이지만,  회원가입버튼을 클릭하면 alert창이 활성화 되는것처럼 버튼을 클릭하면 창이 뜹니다
 - 이런식으로 씁니다. 
 
```
  const [isToastOpen, setIsToastOpen] = useState(true);
  const onclickToastHandler = (open: boolean) => () => {
    setIsToastOpen(open);
  };

//Return문 안에는 아래 코드 
        <Toast isOpen={isToastOpen} onClose={onclickToastHandler(false)}>
          가입이 완료되었습니다.
        </Toast>
        <Button
          variant="border"
          color="success"
          onClick={onclickToastHandler(true)}
        >
          Toast Open Button
        </Button>
 ```

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 📷스크린샷
PR과 관련된 UI 변경사항이 있다면, 스크린샷을 포함시키세요.


https://github.com/user-attachments/assets/ab2b4240-41d7-403d-9d29-0b83a4d37ecd


