### PR TITLE
feat: 스크롤 오버레이 모달 구현

### DIFF
--- a/src/app/(page)/sk/page.tsx
+++ b/src/app/(page)/sk/page.tsx
@@ -189,7 +189,7 @@ const sk = () => {
           isOpen={isModalOpen}
           onClose={handleCloseModal}
           title="Sample Modal"
-          size="xs"
+          size="medium"
           closeButtonText="Close"
           showCloseIcon={true}
         >
@@ -198,7 +198,17 @@ const sk = () => {
             consequat elit dolor adipisicing. Mollit dolor eiusmod sunt ex
             incididunt cillum quis. Velit duis sit officia eiusmod Lorem aliqua
             enim laboris do dolor eiusmod. Et mollit incididunt nisi consectetur
-            esse laborum eiusmod pariatur proident Lorem eiusmod et.
+            esse laborum eiusmod pariatur proident Lorem eiusmod et. Magna
+            exercitation reprehenderit magna aute tempor cupidatat consequat
+            elit dolor adipisicing. Mollit dolor eiusmod sunt ex incididunt
+            cillum quis. Velit duis sit officia eiusmod Lorem aliqua enim
+            laboris do dolor eiusmod. Et mollit incididunt nisi consectetur esse
+            laborum eiusmod pariatur proident Lorem eiusmod et. Magna
+            exercitation reprehenderit magna aute tempor cupidatat consequat
+            elit dolor adipisicing. Mollit dolor eiusmod sunt ex incididunt
+            cillum quis. Velit duis sit officia eiusmod Lorem aliqua enim
+            laboris do dolor eiusmod. Et mollit incididunt nisi consectetur esse
+            laborum eiusmod pariatur proident Lorem eiusmod et. Magna
           </p>
         </OverlayModal>
       </div>

--- a/src/app/(page)/sk/page.tsx
+++ b/src/app/(page)/sk/page.tsx
@@ -13,11 +13,13 @@ import FullScreenSpinner from "@components/Spinner/ FullScreenSpinner";
 import PacManSpinner from "@components/Spinner/PacManSpinner";
 import BasicModal from "@components/Modal/BasicModal";
 import { ExtraSize } from "types/type";
+import OverlayModal from "@components/Modal/OverlayModal";
 
 const sk = () => {
   const [spinning, setSpinning] = useState(false); //fullscreen
   const [isOpen, setIsOpen] = useState(false); //모달
   const [modalSize, setModalSize] = useState<ExtraSize | "full">("medium");
+  const [isModalOpen, setIsModalOpen] = useState(false); //오버레이 모달
 
   const showLoader = () => {
     setSpinning(true);
@@ -26,12 +28,23 @@ const sk = () => {
       setSpinning(false);
     }, 3000); // 3초 동안 스피너를 표시한 후 숨김
   };
+
+  //베이직 모달
   const openModal = (size: ExtraSize | "full") => {
     setModalSize(size);
     setIsOpen(true);
   };
 
   const closeModal = () => setIsOpen(false);
+
+  //오버레이모달
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
 
   const sizes: (ExtraSize | "full")[] = [
     "xs",
@@ -130,7 +143,7 @@ const sk = () => {
 
       {/* Modal */}
       <div className="ml-4 mt-4 space-x-3 space-y-6">
-        <h1 className="mb-4 text-2xl font-bold">Modal Size Example</h1>
+        <h1 className="mb-4 text-2xl font-bold">Basic Modal</h1>
         <div className="space-x-4">
           {sizes.map((size) => (
             <Button key={size} onClick={() => openModal(size)}>
@@ -153,6 +166,7 @@ const sk = () => {
             variant: "secondary",
             onClick: closeModal,
           }}
+          showCloseIcon={true}
         >
           <h2 className="mb-4 text-lg font-bold">Modal Size: {modalSize}</h2>
           <p>
@@ -163,6 +177,30 @@ const sk = () => {
             esse laborum eiusmod pariatur proident Lorem eiusmod et.
           </p>
         </BasicModal>
+      </div>
+
+      <div className="ml-4 mt-4 space-x-3 space-y-6">
+        <h1 className="mb-4 text-2xl font-bold">Overlay Modal</h1>
+        <Button variant="border" onClick={handleOpenModal}>
+          Open overlay Modal
+        </Button>
+
+        <OverlayModal
+          isOpen={isModalOpen}
+          onClose={handleCloseModal}
+          title="Sample Modal"
+          size="xs"
+          closeButtonText="Close"
+          showCloseIcon={true}
+        >
+          <p>
+            Magna exercitation reprehenderit magna aute tempor cupidatat
+            consequat elit dolor adipisicing. Mollit dolor eiusmod sunt ex
+            incididunt cillum quis. Velit duis sit officia eiusmod Lorem aliqua
+            enim laboris do dolor eiusmod. Et mollit incididunt nisi consectetur
+            esse laborum eiusmod pariatur proident Lorem eiusmod et.
+          </p>
+        </OverlayModal>
       </div>
     </>
   );

--- a/src/app/(page)/sk/page.tsx
+++ b/src/app/(page)/sk/page.tsx
@@ -180,7 +180,7 @@ const sk = () => {
       </div>
 
       <div className="ml-4 mt-4 space-x-3 space-y-6">
-        <h1 className="mb-4 text-2xl font-bold">Overlay Modal</h1>
+        <h1 className="mb-4 text-2xl font-bold">Overlay Scroll Modal</h1>
         <Button variant="border" onClick={handleOpenModal}>
           Open overlay Modal
         </Button>

--- a/src/components/Modal/BasicModal.tsx
+++ b/src/components/Modal/BasicModal.tsx
@@ -1,12 +1,11 @@
 import React from "react";
 import { ExtraSize } from "types/type";
 
-interface ButtonProps {
+export interface ButtonProps {
   text: string;
   variant?: "primary" | "secondary" | "danger";
   onClick?: () => void;
 }
-
 interface ModalProps {
   open: boolean;
   size?: ExtraSize | "full";
@@ -14,6 +13,7 @@ interface ModalProps {
   children?: any;
   primaryButton?: ButtonProps;
   secondaryButton?: ButtonProps;
+  showCloseIcon?: boolean; // 닫기 아이콘 표시 여부
 }
 
 const sizeClasses = {
@@ -31,13 +31,14 @@ const buttonClasses = {
   danger: "bg-danger text-white px-4 py-2 rounded-md",
 };
 
-const BasicModal: React.FC<ModalProps> = ({
+export const BasicModal: React.FC<ModalProps> = ({
   open,
   size = "medium",
   onClose,
   primaryButton,
   secondaryButton,
   children,
+  showCloseIcon = true,
 }) => {
   if (!open) return null;
 
@@ -46,7 +47,19 @@ const BasicModal: React.FC<ModalProps> = ({
       className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
       style={{ margin: 0 }}
     >
-      <div className={`rounded-lg bg-white p-6 shadow-lg ${sizeClasses[size]}`}>
+      <div
+        className={`relative rounded-lg bg-white p-6 shadow-lg ${sizeClasses[size]}`}
+        onClick={(e) => e.stopPropagation()} // 모달 내부를 클릭하면 이벤트가 div 태그에서 부모로 전파되지 않도록 막기
+      >
+        {/* 닫기 아이콘 */}
+        {showCloseIcon && (
+          <button
+            className="text-gray-500 hover:text-gray-700 absolute right-2 top-2"
+            onClick={onClose}
+          >
+            &times;
+          </button>
+        )}
         {children} {/* 모달 내부에 표시할 내용 */}
         <div className="mt-4 flex justify-center space-x-2">
           {secondaryButton && (

--- a/src/components/Modal/OverlayModal.tsx
+++ b/src/components/Modal/OverlayModal.tsx
@@ -1,0 +1,76 @@
+import Button from "@components/Button/Button";
+import React, { ReactNode } from "react";
+import { createPortal } from "react-dom";
+//모달을 document.body에 렌더링하여 페이지 구조와 독립적으로 관리할 수 있게.
+import { ExtraSize } from "types/type";
+
+interface OverlayModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  title?: string;
+  size?: ExtraSize;
+  closeOnOverlayClick?: boolean;
+  closeButtonText?: string;
+  className?: string;
+  showCloseIcon?: boolean; // 닫기 아이콘 표시 여부
+}
+
+const SizeClass = {
+  xs: "max-w-xs",
+  small: "max-w-sm",
+  medium: "max-w-md",
+  large: "max-w-lg",
+  xl: "max-w-xl",
+  full: "max-w-full w-full h-full",
+};
+
+const OverlayModal: React.FC<OverlayModalProps> = ({
+  isOpen,
+  onClose,
+  children,
+  title,
+  size = "medium",
+  closeOnOverlayClick = true,
+  className = "",
+  closeButtonText = "Close",
+  showCloseIcon = true,
+}) => {
+  if (!isOpen) return null;
+
+  const handleOverlayClick = () => {
+    if (closeOnOverlayClick) onClose();
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 backdrop-blur-sm"
+      onClick={handleOverlayClick}
+    >
+      <div
+        className={`transform overflow-hidden rounded-lg bg-white p-4 shadow-lg transition-all ${SizeClass[size]} ${className}`}
+        onClick={(e) => e.stopPropagation()} // 모달 내부를 클릭하면 이벤트가 div 태그에서 부모로 전파되지 않도록 막기
+      >
+        {showCloseIcon && (
+          <div className="absolute right-4 top-4">
+            <button onClick={onClose} className="text-gray-500">
+              &times;
+            </button>
+          </div>
+        )}
+        {title && (
+          <div className="bg-gray-200 border-gray-300 px-4 py-2">
+            <h2 className="text-lg font-medium">{title}</h2>
+          </div>
+        )}
+        <div className="p-4">{children} </div>
+        <div className="mt-4 flex justify-end space-x-2">
+          <Button onClick={onClose}>{closeButtonText}</Button>
+        </div>
+      </div>
+    </div>,
+    document.body, // 모달을 body에 직접 렌더링
+  );
+};
+
+export default OverlayModal;

--- a/src/components/Modal/OverlayModal.tsx
+++ b/src/components/Modal/OverlayModal.tsx
@@ -17,14 +17,21 @@ interface OverlayModalProps {
 }
 
 const SizeClass = {
-  xs: "max-w-xs",
-  small: "max-w-sm",
-  medium: "max-w-md",
-  large: "max-w-lg",
-  xl: "max-w-xl",
+  xs: "max-w-xs w-11/12 sm:w-auto",
+  small: "max-w-sm w-11/12 sm:w-auto",
+  medium: "max-w-md w-11/12 sm:w-auto",
+  large: "max-w-lg w-11/12 sm:w-auto",
+  xl: "max-w-xl w-11/12 sm:w-auto",
   full: "max-w-full w-full h-full",
 };
-
+const MaxHeight = {
+  xs: "calc(100vh - 650px)",
+  small: "calc(100vh - 600px)",
+  medium: "calc(100vh - 500px)",
+  large: "calc(100vh - 400px)",
+  xl: "calc(100vh - 300px)",
+  full: "100vh",
+};
 const OverlayModal: React.FC<OverlayModalProps> = ({
   isOpen,
   onClose,
@@ -48,7 +55,7 @@ const OverlayModal: React.FC<OverlayModalProps> = ({
       onClick={handleOverlayClick}
     >
       <div
-        className={`transform overflow-hidden rounded-lg bg-white p-4 shadow-lg transition-all ${SizeClass[size]} ${className}`}
+        className={`relative transform overflow-hidden rounded-lg bg-white p-4 shadow-lg transition-all ${SizeClass[size]} ${className}`}
         onClick={(e) => e.stopPropagation()} // 모달 내부를 클릭하면 이벤트가 div 태그에서 부모로 전파되지 않도록 막기
       >
         {showCloseIcon && (
@@ -63,7 +70,12 @@ const OverlayModal: React.FC<OverlayModalProps> = ({
             <h2 className="text-lg font-medium">{title}</h2>
           </div>
         )}
-        <div className="p-4">{children} </div>
+        <div
+          className="overflow-y-auto p-4"
+          style={{ maxHeight: MaxHeight[size] }}
+        >
+          {children}
+        </div>
         <div className="mt-4 flex justify-end space-x-2">
           <Button onClick={onClose}>{closeButtonText}</Button>
         </div>


### PR DESCRIPTION
## 🛰️ Issue Number
 - closed: #64 
## 🪐 작업 내용
 	•  ExtraSize와 속성들을 통해 모달을 구성할 수 있도록 구현되었습니다.
	•   createPortal을 사용하여 모달이 document.body에 직접 렌더링되도록 구현하였습니다.
	•   콘텐츠가 모달 내부에서 스크롤될 수 있도록 최대 높이와 관련된 스타일을 추가하였습니다.
	•   SizeClass와 MaxHeight를 사용하여 모달의 크기와 최대높이를 설정할 수 있습니다.
	•  x 닫기 버튼: x 버튼이 포함되어 있으며, showCloseIcon 속성을 통해 표시 여부를 선택할 수 있습니다.
	•  배경 클릭 시 닫기: closeOnOverlayClick 속성을 통해 배경을 클릭하여 모달을 닫을 수 있는 기능을 추가했습니다.

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 📷스크린샷
https://github.com/user-attachments/assets/1b017a87-c25f-435b-b251-7c60a52eeee4

