### PR TITLE
[Doc] input doc 수정

### DIFF
--- a/src/app/(docs)/input/page.tsx
+++ b/src/app/(docs)/input/page.tsx
@@ -10,17 +10,18 @@ import SearchInput3 from "@components/Input/SearchInput3";
 import NumInput from "@components/Input/NumInput";
 import CurrencyInput from "@components/Input/CurrencyInput";
 import DecimalInput from "@components/Input/DecimalInput";
+import PinInput from "@components/Input/PinInput";
 
 const Input: React.FC = () => {
-  const [copied, setCopied] = useState(false);
+  const [copied, setCopied] = useState<{ [key: number]: boolean }>({});
 
-  const handleCopy = () => {
-    setCopied(true);
-    setTimeout(() => setCopied(false), 500); // 0.5초 후에 상태를 초기화
+  const handleCopy = (index: number) => {
+    setCopied((prev) => ({ ...prev, [index]: true }));
+    setTimeout(() => setCopied((prev) => ({ ...prev, [index]: false })), 500);
   };
 
   return (
-    <div className="prose max-w-[1000px] text-[#6D6D6D]">
+    <div className="prose mb-40 max-w-[1000px] text-[#6D6D6D]">
       <h1 className="text-[#2D3748]">Input</h1>
       <p>
         <code>Input</code> 컴포넌트는 사용자 입력을 처리하기 위해 사용되는 기본
@@ -32,9 +33,11 @@ const Input: React.FC = () => {
       <div className="relative">
         <CopyToClipboard
           text={`import { Input } from '@components/Input';`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(1)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[1] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`import { Input } from '@componique/react';`}
@@ -57,9 +60,11 @@ function Example() {
 }
 
 export default Example;`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(2)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[2] ? "copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
@@ -121,9 +126,11 @@ function Example() {
   );
 }
 export default Example;`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(3)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[3] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
@@ -239,9 +246,11 @@ function Example() {
 }
 
 export default Example;`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(4)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[4] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
@@ -273,9 +282,11 @@ export default Example;
       <div className="relative">
         <CopyToClipboard
           text={`import SearchInput from '@components/SearchInput/SearchInput';`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(5)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[5] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`import { SearchInput } from '@componique/react';`}
@@ -298,9 +309,11 @@ function Example() {
 }
 
 export default Example;`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(6)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[6] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
@@ -338,9 +351,11 @@ function Example() {
 }
 
 export default Example;`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(7)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[7] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
@@ -376,9 +391,11 @@ function Example() {
 }
 
 export default Example;`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(8)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[8] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
@@ -494,9 +511,11 @@ function Example() {
 }
 
 export default Example;`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(9)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[9] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
@@ -532,9 +551,11 @@ export default Example;
       <div className="relative">
         <CopyToClipboard
           text={`import SearchInput2 from '@components/SearchInput2/SearchInput2';`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(10)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[10] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`import { SearchInput2 } from '@componique/react';`}
@@ -557,9 +578,11 @@ function Example() {
 }
 
 export default Example;`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(11)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[11] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
@@ -612,9 +635,11 @@ function Example() {
 }
 
 export default Example;`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(12)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[12] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
@@ -725,9 +750,11 @@ function Example() {
 }
 
 export default Example;`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(13)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[13] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
@@ -768,9 +795,11 @@ export default Example;
       <div className="relative">
         <CopyToClipboard
           text={`import SearchInput3 from '@components/SearchInput3/SearchInput3';`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(14)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[14] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`import { SearchInput3 } from '@componique/react';`}
@@ -784,9 +813,11 @@ export default Example;
       <div className="relative">
         <CopyToClipboard
           text={`<SearchInput3 placeholder="Search..." />`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(15)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[15] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`<SearchInput3 placeholder="Search..." />`}
@@ -864,9 +895,11 @@ function Example() {
 }
 
 export default Example;`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(16)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[16] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
@@ -898,9 +931,11 @@ export default Example;
       <div className="relative">
         <CopyToClipboard
           text={`import SearchInput3 from '@components/SearchInput3/SearchInput3';`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(17)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[17] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`import {NumInput} from '@componique/react';`}
@@ -908,25 +943,45 @@ export default Example;
       </div>
 
       <h2 className="text-[#2D3748]">Usage</h2>
+      <p>기본 사용 예제는 아래와 같습니다:</p>
       <div style={{ marginBottom: "20px" }}>
         <NumInput
           size="medium"
           color="Basic"
-          value="10"
           onValueChange={(value) => console.log("New value:", value)}
         />
       </div>
-      <CopyToClipboard
-        text={`import SearchInput3 from '@components/SearchInput3/SearchInput3';`}
-        onCopy={handleCopy}
-      >
-        <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
-      </CopyToClipboard>
-      <SyntaxHighlighter language="tsx">
-        {`
-    <NumInput size="medium" color="Primary" />
-        `}
-      </SyntaxHighlighter>
+      <div className="relative">
+        <CopyToClipboard
+          text={`import NumInput from '@components/Input/NumInput';
+
+function Example() {
+  return (
+    <NumInput/>
+  );
+}
+
+export default Example;`}
+          onCopy={() => handleCopy(18)}
+        >
+          <button className="copyButton">
+            {copied[18] ? "Copied!" : "Copy"}
+          </button>
+        </CopyToClipboard>
+        <SyntaxHighlighter language="tsx">
+          {`
+import NumInput from '@components/Input/NumInput';
+
+function Example() {
+  return (
+    <NumInput />
+  );
+}
+
+export default Example;
+`}
+        </SyntaxHighlighter>
+      </div>
 
       <h2 className="text-[#2D3748]">Props</h2>
       <p>
@@ -1018,25 +1073,49 @@ export default Example;
           onValueChange={(value) => console.log("Updated value:", value)}
         />
       </div>
-      <SyntaxHighlighter language="tsx">
-        {`
-import NumInput from '@components/NumInput';
+      <div className="relative">
+        <CopyToClipboard
+          text={`import NumInput from '@components/Input/NumInput';
 
 function FullExample() {
   return (
-    <NumInput 
-      size="large" 
-      color="Basic" 
-      value="5" 
-      width="250px" 
-      onValueChange={(value) => console.log("Updated value:", value)} 
-    />
+    <NumInput
+    size="large"
+    color="Basic"
+    value="5"
+    width="250px"
+    onValueChange={(value) => console.log("Updated value:", value)}
+  />
+  );
+}
+
+export default FullExample;`}
+          onCopy={() => handleCopy(19)}
+        >
+          <button className="copyButton">
+            {copied[19] ? "Copied!" : "Copy"}
+          </button>
+        </CopyToClipboard>
+        <SyntaxHighlighter language="tsx">
+          {`
+import NumInput from '@components/Input/NumInput';
+
+function FullExample() {
+  return (
+    <NumInput
+    size="large"
+    color="Basic"
+    value="5"
+    width="250px"
+    onValueChange={(value) => console.log("Updated value:", value)}
+  />
   );
 }
 
 export default FullExample;
-        `}
-      </SyntaxHighlighter>
+    `}
+        </SyntaxHighlighter>
+      </div>
 
       <h1 className="mt-40 text-[#2D3748]">CurrencyInput</h1>
       <p>
@@ -1049,9 +1128,11 @@ export default FullExample;
       <div className="relative">
         <CopyToClipboard
           text={`import CurrencyInput from '@components/Input/CurrencyInput';`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(20)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[20] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`import { CurrencyInput } from '@componique/react';`}
@@ -1069,23 +1150,25 @@ export default FullExample;
       </div>
       <div className="relative">
         <CopyToClipboard
-          text={`<CurrencyInput 
-  size="medium" 
-  color="Primary" 
-  value="$10.00" 
-  onValueChange={(value) => console.log("New value:", value)} 
+          text={`<CurrencyInput
+  size="medium"
+  color="Primary"
+  value="$10.00"
+  onValueChange={(value) => console.log("New value:", value)}
 />`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(21)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[21] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
-<CurrencyInput 
-  size="medium" 
-  color="Primary" 
-  value="$10.00" 
-  onValueChange={(value) => console.log("New value:", value)} 
+<CurrencyInput
+  size="medium"
+  color="Primary"
+  value="$10.00"
+  onValueChange={(value) => console.log("New value:", value)}
 />
     `}
         </SyntaxHighlighter>
@@ -1187,20 +1270,22 @@ export default FullExample;
 
 function FullExample() {
   return (
-    <CurrencyInput 
-      size="large" 
-      color="Basic" 
-      value="$50.00" 
-      width="300px" 
-      onValueChange={(value) => console.log("Updated value:", value)} 
+    <CurrencyInput
+      size="large"
+      color="Basic"
+      value="$50.00"
+      width="300px"
+      onValueChange={(value) => console.log("Updated value:", value)}
     />
   );
 }
 
 export default FullExample;`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(22)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[22] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
@@ -1208,12 +1293,12 @@ import CurrencyInput from '@components/Input/CurrencyInput';
 
 function FullExample() {
   return (
-    <CurrencyInput 
-      size="large" 
-      color="Basic" 
-      value="$50.00" 
-      width="300px" 
-      onValueChange={(value) => console.log("Updated value:", value)} 
+    <CurrencyInput
+      size="large"
+      color="Basic"
+      value="$50.00"
+      width="300px"
+      onValueChange={(value) => console.log("Updated value:", value)}
     />
   );
 }
@@ -1235,9 +1320,11 @@ export default FullExample;
       <div className="relative">
         <CopyToClipboard
           text={`import DecimalInput from '@components/Input/DecimalInput';`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(23)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[23] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`import { DecimalInput } from '@componique/react';`}
@@ -1249,29 +1336,30 @@ export default FullExample;
         <DecimalInput
           size="medium"
           color="Primary"
-          value="10.00"
           onValueChange={(value) => console.log("New value:", value)}
         />
       </div>
       <div className="relative">
         <CopyToClipboard
-          text={`<DecimalInput 
-  size="medium" 
-  color="Primary" 
-  value="10.00" 
-  onValueChange={(value) => console.log("New value:", value)} 
+          text={`<DecimalInput
+  size="medium"
+  color="Primary"
+  value="10.00"
+  onValueChange={(value) => console.log("New value:", value)}
 />`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(24)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[24] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
-<DecimalInput 
-  size="medium" 
-  color="Primary" 
-  value="10.00" 
-  onValueChange={(value) => console.log("New value:", value)} 
+<DecimalInput
+  size="medium"
+  color="Primary"
+  value="10.00"
+  onValueChange={(value) => console.log("New value:", value)}
 />
     `}
         </SyntaxHighlighter>
@@ -1373,20 +1461,22 @@ export default FullExample;
 
 function FullExample() {
   return (
-    <DecimalInput 
-      size="large" 
-      color="Basic" 
-      value="50.00" 
-      width="300px" 
-      onValueChange={(value) => console.log("Updated value:", value)} 
+    <DecimalInput
+      size="large"
+      color="Basic"
+      value="50.00"
+      width="300px"
+      onValueChange={(value) => console.log("Updated value:", value)}
     />
   );
 }
 
 export default FullExample;`}
-          onCopy={handleCopy}
+          onCopy={() => handleCopy(25)}
         >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+          <button className="copyButton">
+            {copied[25] ? "Copied!" : "Copy"}
+          </button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
           {`
@@ -1394,18 +1484,263 @@ import DecimalInput from '@components/Input/DecimalInput';
 
 function FullExample() {
   return (
-    <DecimalInput 
-      size="large" 
-      color="Basic" 
-      value="50.00" 
-      width="300px" 
-      onValueChange={(value) => console.log("Updated value:", value)} 
+    <DecimalInput
+      size="large"
+      color="Basic"
+      value="50.00"
+      width="300px"
+      onValueChange={(value) => console.log("Updated value:", value)}
     />
   );
 }
 
 export default FullExample;
     `}
+        </SyntaxHighlighter>
+      </div>
+
+      <h1 className="mt-40 text-[#2D3748]">PinInput</h1>
+      <p>
+        <code>PinInput</code> 컴포넌트는 사용자에게 PIN 코드를 입력받기 위한 UI
+        요소입니다. 사용자는 각 입력 칸에 개별적으로 숫자를 입력할 수 있으며,
+        숫자가 입력되면 자동으로 다음 칸으로 포커스가 이동합니다.
+      </p>
+
+      <h2 className="text-[#2D3748]">Import</h2>
+      <div className="relative">
+        <CopyToClipboard
+          text={`import PinInput from '@components/Input/PinInput';`}
+          onCopy={() => handleCopy(26)}
+        >
+          <button className="copyButton">
+            {copied[26] ? "Copied!" : "Copy"}
+          </button>
+        </CopyToClipboard>
+        <SyntaxHighlighter language="tsx">
+          {`import { PinInput } from '@componique/react';`}
+        </SyntaxHighlighter>
+      </div>
+
+      <h2 className="text-[#2D3748]">Usage</h2>
+      <p>기본 사용 예제는 아래와 같습니다:</p>
+      <div style={{ marginBottom: "20px" }}>
+        <PinInput length={4} />
+      </div>
+      <div className="relative">
+        <CopyToClipboard
+          text={`import PinInput from '@components/Input/PinInput';
+
+function Example() {
+  return (
+    <PinInput length={4} />
+  );
+}
+
+export default Example;`}
+          onCopy={() => handleCopy(27)}
+        >
+          <button className="copyButton">
+            {copied[27] ? "Copied!" : "Copy"}
+          </button>
+        </CopyToClipboard>
+        <SyntaxHighlighter language="tsx">
+          {`
+import PinInput from '@components/Input/PinInput';
+
+function Example() {
+  return (
+    <PinInput length={4} />
+  );
+}
+
+export default Example;
+`}
+        </SyntaxHighlighter>
+      </div>
+
+      <h2 className="text-[#2D3748]">Customizing the PinInput</h2>
+      <p>
+        <code>PinInput</code> 컴포넌트는 다양한 옵션을 통해 커스터마이징 할 수
+        있습니다. 예를 들어, 필드의 개수, 변형 스타일, 비활성화 상태 등을 설정할
+        수 있습니다:
+      </p>
+      <div style={{ marginBottom: "10px" }}>
+        <PinInput length={6} variant="filled" disabled={true} />
+      </div>
+      <div style={{ marginBottom: "20px" }}>
+        <PinInput customCharacter="🥳" />
+      </div>
+      <div className="relative">
+        <CopyToClipboard
+          text={`import PinInput from '@components/Input/PinInput';
+
+function Example() {
+  return (
+    <PinInput length={6} variant="filled" disabled={true} />
+    <PinInput customCharacter="🥳" />
+  );
+}
+
+export default Example;`}
+          onCopy={() => handleCopy(28)}
+        >
+          <button className="copyButton">
+            {copied[28] ? "Copied!" : "Copy"}
+          </button>
+        </CopyToClipboard>
+        <SyntaxHighlighter language="tsx">
+          {`
+import PinInput from '@components/Input/PinInput';
+
+function Example() {
+  return (
+    <PinInput length={6} variant="filled" disabled={true} />
+    <PinInput customCharacter="🥳" />
+  );
+}
+
+export default Example;
+`}
+        </SyntaxHighlighter>
+      </div>
+
+      <h2 className="text-[#2D3748]">Props</h2>
+      <p>
+        <code>PinInput</code> 컴포넌트는 다음과 같은 props를 가집니다:
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Prop</th>
+            <th>Description</th>
+            <th>Type</th>
+            <th>Default</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>length</code>
+            </td>
+            <td>PIN 입력 칸의 개수를 설정합니다.</td>
+            <td>
+              <code>number</code>
+            </td>
+            <td>
+              <code>6</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>disabled</code>
+            </td>
+            <td>입력 필드를 비활성화할지 여부를 설정합니다.</td>
+            <td>
+              <code>boolean</code>
+            </td>
+            <td>
+              <code>false</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>formatter</code>
+            </td>
+            <td>입력된 값을 형식화하기 위한 함수입니다.</td>
+            <td>
+              <code>(value: string) =&gt; string</code>
+            </td>
+            <td>
+              <code>-</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>variant</code>
+            </td>
+            <td>입력 필드의 스타일 변형을 설정합니다.</td>
+            <td>
+              <code>"filled" | "outline"</code>
+            </td>
+            <td>
+              <code>"outline"</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>customCharacter</code>
+            </td>
+            <td>입력 대신 표시할 사용자 지정 문자를 설정합니다.</td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>
+              <code>""</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>onChange</code>
+            </td>
+            <td>값이 변경될 때 호출되는 콜백 함수입니다.</td>
+            <td>
+              <code>(value: string) =&gt; void</code>
+            </td>
+            <td>
+              <code>-</code>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2 className="text-[#2D3748]">Full Example</h2>
+      <div style={{ marginBottom: "20px" }}>
+        <PinInput
+          length={4}
+          variant="filled"
+          formatter={(value) => value.toUpperCase()}
+          onChange={(value) => console.log("Updated PIN:", value)}
+        />
+      </div>
+      <div className="relative">
+        <CopyToClipboard
+          text={`import PinInput from '@components/Input/PinInput';
+
+function FullExample() {
+  return (
+    <PinInput
+      length={4}
+      variant="filled"
+      formatter={(value) => value.toUpperCase()}
+      onChange={(value) => console.log("Updated PIN:", value)}
+    />
+  );
+}
+
+export default FullExample;`}
+          onCopy={() => handleCopy(29)}
+        >
+          <button className="copyButton">
+            {copied[29] ? "Copied!" : "Copy"}
+          </button>
+        </CopyToClipboard>
+        <SyntaxHighlighter language="tsx">
+          {`
+import PinInput from '@components/Input/PinInput';
+
+function FullExample() {
+  return (
+    <PinInput
+      length={4}
+      variant="filled"
+      formatter={(value) => value.toUpperCase()}
+      onChange={(value) => console.log("Updated PIN:", value)}
+    />
+  );
+}
+
+export default FullExample;
+`}
         </SyntaxHighlighter>
       </div>
     </div>

--- a/src/app/(docs)/input/page.tsx
+++ b/src/app/(docs)/input/page.tsx
@@ -11,6 +11,7 @@ import NumInput from "@components/Input/NumInput";
 import CurrencyInput from "@components/Input/CurrencyInput";
 import DecimalInput from "@components/Input/DecimalInput";
 import PinInput from "@components/Input/PinInput";
+import CodeBox from "@components/CodeBox";
 
 const Input: React.FC = () => {
   const [copied, setCopied] = useState<{ [key: number]: boolean }>({});
@@ -30,44 +31,22 @@ const Input: React.FC = () => {
       </p>
 
       <h2 className="text-[#2D3748]">Import</h2>
-      <div className="relative">
-        <CopyToClipboard
-          text={`import { Input } from '@components/Input';`}
-          onCopy={() => handleCopy(1)}
-        >
-          <button className="copyButton">
-            {copied[1] ? "Copied!" : "Copy"}
-          </button>
-        </CopyToClipboard>
-        <SyntaxHighlighter language="tsx">
-          {`import { Input } from '@componique/react';`}
-        </SyntaxHighlighter>
-      </div>
+      <CodeBox
+        code={`import { Input } from '@componique/react';`}
+        copyText={`import { Input } from '@components/Input';`}
+        language="tsx"
+        index={1}
+        copied={copied}
+        handleCopy={handleCopy}
+      />
 
       <h2 className="text-[#2D3748]">Usage</h2>
       <p>기본 사용 예제는 아래와 같습니다:</p>
       <div style={{ marginBottom: "20px" }}>
         <Input1 placeholder="Basic usage" />
       </div>
-      <div className="relative">
-        <CopyToClipboard
-          text={`import { Input } from '@components/Input';
-
-function Example() {
-  return (
-    <Input placeholder="Basic usage" />
-  );
-}
-
-export default Example;`}
-          onCopy={() => handleCopy(2)}
-        >
-          <button className="copyButton">
-            {copied[2] ? "copied!" : "Copy"}
-          </button>
-        </CopyToClipboard>
-        <SyntaxHighlighter language="tsx">
-          {`
+      <CodeBox
+        code={`
 import { Input } from '@components/Input';
 
 function Example() {
@@ -78,8 +57,20 @@ function Example() {
 
 export default Example;
 `}
-        </SyntaxHighlighter>
-      </div>
+        copyText={`import { Input } from '@components/Input';
+
+function Example() {
+  return (
+    <Input placeholder="Basic usage" />
+  );
+}
+
+export default Example;`}
+        language="tsx"
+        index={2}
+        copied={copied}
+        handleCopy={handleCopy}
+      />
 
       <h2 className="text-[#2D3748]">Changing the Size of the Input</h2>
       <p>

--- a/src/app/(docs)/input/page.tsx
+++ b/src/app/(docs)/input/page.tsx
@@ -20,7 +20,7 @@ const Input: React.FC = () => {
   };
 
   return (
-    <div className="prose p-5 text-[#6D6D6D]">
+    <div className="prose max-w-[1000px] text-[#6D6D6D]">
       <h1 className="text-[#2D3748]">Input</h1>
       <p>
         <code>Input</code> 컴포넌트는 사용자 입력을 처리하기 위해 사용되는 기본

--- a/src/app/(docs)/input/page.tsx
+++ b/src/app/(docs)/input/page.tsx
@@ -278,7 +278,7 @@ export default Example;
           <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
-        {`import { SearchInput } from '@componique/react';`}
+          {`import { SearchInput } from '@componique/react';`}
         </SyntaxHighlighter>
       </div>
 
@@ -317,10 +317,12 @@ export default Example;
         </SyntaxHighlighter>
       </div>
 
-      <h2 className="text-[#2D3748]">Changing the Active and Inactive Colors</h2>
+      <h2 className="text-[#2D3748]">
+        Changing the Active and Inactive Colors
+      </h2>
       <p>
-        <code>SearchInput</code> 컴포넌트는 활성화 및 비활성화 상태에 따른 색상을
-        커스터마이즈할 수 있습니다. 예제는 다음과 같습니다:
+        <code>SearchInput</code> 컴포넌트는 활성화 및 비활성화 상태에 따른
+        색상을 커스터마이즈할 수 있습니다. 예제는 다음과 같습니다:
       </p>
       <div style={{ marginBottom: "20px" }}>
         <SearchInput activeColor="bg-Primary" inactiveColor="bg-gray-400" />
@@ -357,8 +359,8 @@ export default Example;
 
       <h2 className="text-[#2D3748]">Changing the Width of the Input</h2>
       <p>
-        <code>SearchInput</code> 컴포넌트의 너비는 동적으로 조정 가능합니다. 기본
-        너비는 <code>w-80</code>입니다.
+        <code>SearchInput</code> 컴포넌트의 너비는 동적으로 조정 가능합니다.
+        기본 너비는 <code>w-80</code>입니다.
       </p>
       <div style={{ marginBottom: "20px" }}>
         <SearchInput width="w-96" placeholder="Custom width..." />
@@ -459,9 +461,11 @@ export default Example;
             <td>
               <code>onSearch</code>
             </td>
-            <td>사용자가 검색어를 입력하고 확인을 클릭했을 때 호출되는 함수입니다.</td>
             <td>
-              <code>(value: string) => void</code>
+              사용자가 검색어를 입력하고 확인을 클릭했을 때 호출되는 함수입니다.
+            </td>
+            <td>
+              <code>(value: string) =&gt; void</code>
             </td>
             <td>
               <code>-</code>
@@ -533,7 +537,7 @@ export default Example;
           <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
-        {`import { SearchInput2 } from '@componique/react';`}
+          {`import { SearchInput2 } from '@componique/react';`}
         </SyntaxHighlighter>
       </div>
 
@@ -574,8 +578,8 @@ export default Example;
 
       <h2 className="text-[#2D3748]">Changing the Size of the Input</h2>
       <p>
-        <code>SearchInput2</code> 컴포넌트는 다양한 크기로 제공됩니다. 기본 크기는{" "}
-        <code>medium</code>입니다:
+        <code>SearchInput2</code> 컴포넌트는 다양한 크기로 제공됩니다. 기본
+        크기는 <code>medium</code>입니다:
       </p>
       <ul>
         <li>
@@ -756,7 +760,8 @@ export default Example;
       </div>
       <h1 className="mt-40 text-[#2D3748]">SearchInput3</h1>
       <p>
-        <code>SearchInput3</code> 컴포넌트는 검색 입력 필드와 버튼을 함께 제공하는 UI 요소입니다.
+        <code>SearchInput3</code> 컴포넌트는 검색 입력 필드와 버튼을 함께
+        제공하는 UI 요소입니다.
       </p>
 
       <h2 className="text-[#2D3748]">Import</h2>
@@ -768,7 +773,7 @@ export default Example;
           <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
         </CopyToClipboard>
         <SyntaxHighlighter language="tsx">
-        {`import { SearchInput3 } from '@componique/react';`}
+          {`import { SearchInput3 } from '@componique/react';`}
         </SyntaxHighlighter>
       </div>
 
@@ -815,7 +820,10 @@ export default Example;
               <code>color</code>
             </td>
             <td>
-              <code>"Basic" | "Primary" | "Secondary" | "Success" | "Warning" | "Danger"</code>
+              <code>
+                "Basic" | "Primary" | "Secondary" | "Success" | "Warning" |
+                "Danger"
+              </code>
             </td>
             <td>
               <code>"Basic"</code>
@@ -825,13 +833,25 @@ export default Example;
       </table>
       <h2 className="text-[#2D3748]">Full Example</h2>
       <div className="ml-4 space-y-3">
-      <SearchInput3 size="small" color="Basic" placeholder="Small Search..." />
-      <SearchInput3 size="medium" color="Primary" placeholder="Medium Search..." />
-      <SearchInput3 size="large" color="Danger" placeholder="Large Search..." />
+        <SearchInput3
+          size="small"
+          color="Basic"
+          placeholder="Small Search..."
+        />
+        <SearchInput3
+          size="medium"
+          color="Primary"
+          placeholder="Medium Search..."
+        />
+        <SearchInput3
+          size="large"
+          color="Danger"
+          placeholder="Large Search..."
+        />
       </div>
-<div className="relative">
-  <CopyToClipboard
-    text={`import SearchInput3 from '@components/SearchInput3/SearchInput3';
+      <div className="relative">
+        <CopyToClipboard
+          text={`import SearchInput3 from '@components/SearchInput3/SearchInput3';
 
 function Example() {
   return (
@@ -844,12 +864,12 @@ function Example() {
 }
 
 export default Example;`}
-    onCopy={handleCopy}
-  >
-    <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
-  </CopyToClipboard>
-  <SyntaxHighlighter language="tsx">
-    {`
+          onCopy={handleCopy}
+        >
+          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+        </CopyToClipboard>
+        <SyntaxHighlighter language="tsx">
+          {`
 import SearchInput3 from '@components/SearchInput3/SearchInput3';
 
 function Example() {
@@ -864,10 +884,10 @@ function Example() {
 
 export default Example;
 `}
-  </SyntaxHighlighter>
-  </div>
+        </SyntaxHighlighter>
+      </div>
 
-  <h1 className="mt-40 text-[#2D3748]">NumInput</h1>
+      <h1 className="mt-40 text-[#2D3748]">NumInput</h1>
       <p>
         <code>NumInput</code> 컴포넌트는 숫자를 입력하거나 증감할 수 있는
         인터페이스를 제공합니다. 버튼을 사용해 숫자를 증가시키거나 감소시킬 수
@@ -887,7 +907,6 @@ export default Example;
         </SyntaxHighlighter>
       </div>
 
-
       <h2 className="text-[#2D3748]">Usage</h2>
       <div style={{ marginBottom: "20px" }}>
         <NumInput
@@ -898,11 +917,11 @@ export default Example;
         />
       </div>
       <CopyToClipboard
-          text={`import SearchInput3 from '@components/SearchInput3/SearchInput3';`}
-          onCopy={handleCopy}
-        >
-          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
-        </CopyToClipboard>
+        text={`import SearchInput3 from '@components/SearchInput3/SearchInput3';`}
+        onCopy={handleCopy}
+      >
+        <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+      </CopyToClipboard>
       <SyntaxHighlighter language="tsx">
         {`
     <NumInput size="medium" color="Primary" />
@@ -941,7 +960,10 @@ export default Example;
             </td>
             <td>버튼의 색상을 설정합니다.</td>
             <td>
-              <code>"Basic" | "Primary" | "Secondary" | "Success" | "Warning" | "Gray" | "Danger"</code>
+              <code>
+                "Basic" | "Primary" | "Secondary" | "Success" | "Warning" |
+                "Gray" | "Danger"
+              </code>
             </td>
             <td>
               <code>"Basic"</code>
@@ -1017,38 +1039,48 @@ export default FullExample;
       </SyntaxHighlighter>
 
       <h1 className="mt-40 text-[#2D3748]">CurrencyInput</h1>
-<p>
-  <code>CurrencyInput</code> 컴포넌트는 금액을 입력하거나 증감할 수 있는 인터페이스를 제공합니다. 사용자가 입력 필드를 통해 금액을 입력하거나, 증감 버튼을 통해 금액을 조정할 수 있습니다.
-</p>
+      <p>
+        <code>CurrencyInput</code> 컴포넌트는 금액을 입력하거나 증감할 수 있는
+        인터페이스를 제공합니다. 사용자가 입력 필드를 통해 금액을 입력하거나,
+        증감 버튼을 통해 금액을 조정할 수 있습니다.
+      </p>
 
-<h2 className="text-[#2D3748]">Import</h2>
-<div className="relative">
-  <CopyToClipboard text={`import CurrencyInput from '@components/Input/CurrencyInput';`} onCopy={handleCopy}>
-    <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
-  </CopyToClipboard>
-  <SyntaxHighlighter language="tsx">
-    {`import { CurrencyInput } from '@componique/react';`}
-  </SyntaxHighlighter>
-</div>
+      <h2 className="text-[#2D3748]">Import</h2>
+      <div className="relative">
+        <CopyToClipboard
+          text={`import CurrencyInput from '@components/Input/CurrencyInput';`}
+          onCopy={handleCopy}
+        >
+          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+        </CopyToClipboard>
+        <SyntaxHighlighter language="tsx">
+          {`import { CurrencyInput } from '@componique/react';`}
+        </SyntaxHighlighter>
+      </div>
 
-<h2 className="text-[#2D3748]">Usage</h2>
-<div style={{ marginBottom: "20px" }}>
-  <CurrencyInput size="medium" color="Primary" value="$10.00" onValueChange={(value) => console.log("New value:", value)} />
-</div>
-<div className="relative">
-  <CopyToClipboard
-    text={`<CurrencyInput 
+      <h2 className="text-[#2D3748]">Usage</h2>
+      <div style={{ marginBottom: "20px" }}>
+        <CurrencyInput
+          size="medium"
+          color="Primary"
+          value="$10.00"
+          onValueChange={(value) => console.log("New value:", value)}
+        />
+      </div>
+      <div className="relative">
+        <CopyToClipboard
+          text={`<CurrencyInput 
   size="medium" 
   color="Primary" 
   value="$10.00" 
   onValueChange={(value) => console.log("New value:", value)} 
 />`}
-    onCopy={handleCopy}
-  >
-    <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
-  </CopyToClipboard>
-  <SyntaxHighlighter language="tsx">
-    {`
+          onCopy={handleCopy}
+        >
+          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+        </CopyToClipboard>
+        <SyntaxHighlighter language="tsx">
+          {`
 <CurrencyInput 
   size="medium" 
   color="Primary" 
@@ -1056,63 +1088,102 @@ export default FullExample;
   onValueChange={(value) => console.log("New value:", value)} 
 />
     `}
-  </SyntaxHighlighter>
-</div>
+        </SyntaxHighlighter>
+      </div>
 
-<h2 className="text-[#2D3748]">Props</h2>
-<p>
-  <code>CurrencyInput</code> 컴포넌트는 다음과 같은 props를 가집니다:
-</p>
-<table>
-  <thead>
-    <tr>
-      <th>Prop</th>
-      <th>Description</th>
-      <th>Type</th>
-      <th>Default</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>size</code></td>
-      <td>입력 필드 및 버튼의 크기를 설정합니다.</td>
-      <td><code>"small" | "medium" | "large"</code></td>
-      <td><code>"medium"</code></td>
-    </tr>
-    <tr>
-      <td><code>color</code></td>
-      <td>버튼의 색상을 설정합니다.</td>
-      <td><code>"Basic" | "Primary" | "Secondary" | "Success" | "Warning" | "Danger"</code></td>
-      <td><code>"Basic"</code></td>
-    </tr>
-    <tr>
-      <td><code>value</code></td>
-      <td>입력 필드의 초기 금액 값입니다.</td>
-      <td><code>string</code></td>
-      <td><code>"$0.00"</code></td>
-    </tr>
-    <tr>
-      <td><code>onValueChange</code></td>
-      <td>값이 변경될 때 호출되는 콜백 함수입니다.</td>
-      <td><code>(value: string) =&gt; void</code></td>
-      <td><code>-</code></td>
-    </tr>
-    <tr>
-      <td><code>width</code></td>
-      <td>컴포넌트의 너비를 설정합니다.</td>
-      <td><code>string</code></td>
-      <td><code>"200px"</code></td>
-    </tr>
-  </tbody>
-</table>
+      <h2 className="text-[#2D3748]">Props</h2>
+      <p>
+        <code>CurrencyInput</code> 컴포넌트는 다음과 같은 props를 가집니다:
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Prop</th>
+            <th>Description</th>
+            <th>Type</th>
+            <th>Default</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>size</code>
+            </td>
+            <td>입력 필드 및 버튼의 크기를 설정합니다.</td>
+            <td>
+              <code>"small" | "medium" | "large"</code>
+            </td>
+            <td>
+              <code>"medium"</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>color</code>
+            </td>
+            <td>버튼의 색상을 설정합니다.</td>
+            <td>
+              <code>
+                "Basic" | "Primary" | "Secondary" | "Success" | "Warning" |
+                "Danger"
+              </code>
+            </td>
+            <td>
+              <code>"Basic"</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>value</code>
+            </td>
+            <td>입력 필드의 초기 금액 값입니다.</td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>
+              <code>"$0.00"</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>onValueChange</code>
+            </td>
+            <td>값이 변경될 때 호출되는 콜백 함수입니다.</td>
+            <td>
+              <code>(value: string) =&gt; void</code>
+            </td>
+            <td>
+              <code>-</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>width</code>
+            </td>
+            <td>컴포넌트의 너비를 설정합니다.</td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>
+              <code>"200px"</code>
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-<h2 className="text-[#2D3748]">Full Example</h2>
-<div style={{ marginBottom: "20px" }}>
-  <CurrencyInput size="large" color="Basic" value="$50.00" width="300px" onValueChange={(value) => console.log("Updated value:", value)} />
-</div>
-<div className="relative">
-  <CopyToClipboard
-    text={`import CurrencyInput from '@components/Input/CurrencyInput';
+      <h2 className="text-[#2D3748]">Full Example</h2>
+      <div style={{ marginBottom: "20px" }}>
+        <CurrencyInput
+          size="large"
+          color="Basic"
+          value="$50.00"
+          width="300px"
+          onValueChange={(value) => console.log("Updated value:", value)}
+        />
+      </div>
+      <div className="relative">
+        <CopyToClipboard
+          text={`import CurrencyInput from '@components/Input/CurrencyInput';
 
 function FullExample() {
   return (
@@ -1127,12 +1198,12 @@ function FullExample() {
 }
 
 export default FullExample;`}
-    onCopy={handleCopy}
-  >
-    <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
-  </CopyToClipboard>
-  <SyntaxHighlighter language="tsx">
-    {`
+          onCopy={handleCopy}
+        >
+          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+        </CopyToClipboard>
+        <SyntaxHighlighter language="tsx">
+          {`
 import CurrencyInput from '@components/Input/CurrencyInput';
 
 function FullExample() {
@@ -1149,42 +1220,53 @@ function FullExample() {
 
 export default FullExample;
     `}
-  </SyntaxHighlighter>
-</div>
+        </SyntaxHighlighter>
+      </div>
 
       <h1 className="mt-40 text-[#2D3748]">DecimalInput</h1>
-<p>
-  <code>DecimalInput</code> 컴포넌트는 사용자가 소수점이 포함된 숫자를 입력하거나 증감할 수 있도록 도와주는 인터페이스를 제공합니다. 사용자는 입력 필드를 통해 값을 입력하거나, 증감 버튼을 통해 값을 조정할 수 있습니다.
-</p>
+      <p>
+        <code>DecimalInput</code> 컴포넌트는 사용자가 소수점이 포함된 숫자를
+        입력하거나 증감할 수 있도록 도와주는 인터페이스를 제공합니다. 사용자는
+        입력 필드를 통해 값을 입력하거나, 증감 버튼을 통해 값을 조정할 수
+        있습니다.
+      </p>
 
-<h2 className="text-[#2D3748]">Import</h2>
-<div className="relative">
-  <CopyToClipboard text={`import DecimalInput from '@components/Input/DecimalInput';`} onCopy={handleCopy}>
-    <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
-  </CopyToClipboard>
-  <SyntaxHighlighter language="tsx">
-    {`import { DecimalInput } from '@componique/react';`}
-  </SyntaxHighlighter>
-</div>
+      <h2 className="text-[#2D3748]">Import</h2>
+      <div className="relative">
+        <CopyToClipboard
+          text={`import DecimalInput from '@components/Input/DecimalInput';`}
+          onCopy={handleCopy}
+        >
+          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+        </CopyToClipboard>
+        <SyntaxHighlighter language="tsx">
+          {`import { DecimalInput } from '@componique/react';`}
+        </SyntaxHighlighter>
+      </div>
 
-<h2 className="text-[#2D3748]">Usage</h2>
-<div style={{ marginBottom: "20px" }}>
-  <DecimalInput size="medium" color="Primary" value="10.00" onValueChange={(value) => console.log("New value:", value)} />
-</div>
-<div className="relative">
-  <CopyToClipboard
-    text={`<DecimalInput 
+      <h2 className="text-[#2D3748]">Usage</h2>
+      <div style={{ marginBottom: "20px" }}>
+        <DecimalInput
+          size="medium"
+          color="Primary"
+          value="10.00"
+          onValueChange={(value) => console.log("New value:", value)}
+        />
+      </div>
+      <div className="relative">
+        <CopyToClipboard
+          text={`<DecimalInput 
   size="medium" 
   color="Primary" 
   value="10.00" 
   onValueChange={(value) => console.log("New value:", value)} 
 />`}
-    onCopy={handleCopy}
-  >
-    <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
-  </CopyToClipboard>
-  <SyntaxHighlighter language="tsx">
-    {`
+          onCopy={handleCopy}
+        >
+          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+        </CopyToClipboard>
+        <SyntaxHighlighter language="tsx">
+          {`
 <DecimalInput 
   size="medium" 
   color="Primary" 
@@ -1192,63 +1274,102 @@ export default FullExample;
   onValueChange={(value) => console.log("New value:", value)} 
 />
     `}
-  </SyntaxHighlighter>
-</div>
+        </SyntaxHighlighter>
+      </div>
 
-<h2 className="text-[#2D3748]">Props</h2>
-<p>
-  <code>DecimalInput</code> 컴포넌트는 다음과 같은 props를 가집니다:
-</p>
-<table>
-  <thead>
-    <tr>
-      <th>Prop</th>
-      <th>Description</th>
-      <th>Type</th>
-      <th>Default</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td><code>size</code></td>
-      <td>입력 필드 및 버튼의 크기를 설정합니다.</td>
-      <td><code>"small" | "medium" | "large"</code></td>
-      <td><code>"medium"</code></td>
-    </tr>
-    <tr>
-      <td><code>color</code></td>
-      <td>버튼의 색상을 설정합니다.</td>
-      <td><code>"Basic" | "Primary" | "Secondary" | "Success" | "Warning" | "Gray" | "Danger"</code></td>
-      <td><code>"Basic"</code></td>
-    </tr>
-    <tr>
-      <td><code>value</code></td>
-      <td>입력 필드의 초기 값입니다.</td>
-      <td><code>string</code></td>
-      <td><code>"0.00"</code></td>
-    </tr>
-    <tr>
-      <td><code>onValueChange</code></td>
-      <td>값이 변경될 때 호출되는 콜백 함수입니다.</td>
-      <td><code>(value: string) =&gt; void</code></td>
-      <td><code>-</code></td>
-    </tr>
-    <tr>
-      <td><code>width</code></td>
-      <td>컴포넌트의 너비를 설정합니다.</td>
-      <td><code>string</code></td>
-      <td><code>"200px"</code></td>
-    </tr>
-  </tbody>
-</table>
+      <h2 className="text-[#2D3748]">Props</h2>
+      <p>
+        <code>DecimalInput</code> 컴포넌트는 다음과 같은 props를 가집니다:
+      </p>
+      <table>
+        <thead>
+          <tr>
+            <th>Prop</th>
+            <th>Description</th>
+            <th>Type</th>
+            <th>Default</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <code>size</code>
+            </td>
+            <td>입력 필드 및 버튼의 크기를 설정합니다.</td>
+            <td>
+              <code>"small" | "medium" | "large"</code>
+            </td>
+            <td>
+              <code>"medium"</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>color</code>
+            </td>
+            <td>버튼의 색상을 설정합니다.</td>
+            <td>
+              <code>
+                "Basic" | "Primary" | "Secondary" | "Success" | "Warning" |
+                "Gray" | "Danger"
+              </code>
+            </td>
+            <td>
+              <code>"Basic"</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>value</code>
+            </td>
+            <td>입력 필드의 초기 값입니다.</td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>
+              <code>"0.00"</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>onValueChange</code>
+            </td>
+            <td>값이 변경될 때 호출되는 콜백 함수입니다.</td>
+            <td>
+              <code>(value: string) =&gt; void</code>
+            </td>
+            <td>
+              <code>-</code>
+            </td>
+          </tr>
+          <tr>
+            <td>
+              <code>width</code>
+            </td>
+            <td>컴포넌트의 너비를 설정합니다.</td>
+            <td>
+              <code>string</code>
+            </td>
+            <td>
+              <code>"200px"</code>
+            </td>
+          </tr>
+        </tbody>
+      </table>
 
-<h2 className="text-[#2D3748]">Full Example</h2>
-<div style={{ marginBottom: "20px" }}>
-  <DecimalInput size="large" color="Basic" value="50.00" width="300px" onValueChange={(value) => console.log("Updated value:", value)} />
-</div>
-<div className="relative">
-  <CopyToClipboard
-    text={`import DecimalInput from '@components/Input/DecimalInput';
+      <h2 className="text-[#2D3748]">Full Example</h2>
+      <div style={{ marginBottom: "20px" }}>
+        <DecimalInput
+          size="large"
+          color="Basic"
+          value="50.00"
+          width="300px"
+          onValueChange={(value) => console.log("Updated value:", value)}
+        />
+      </div>
+      <div className="relative">
+        <CopyToClipboard
+          text={`import DecimalInput from '@components/Input/DecimalInput';
 
 function FullExample() {
   return (
@@ -1263,12 +1384,12 @@ function FullExample() {
 }
 
 export default FullExample;`}
-    onCopy={handleCopy}
-  >
-    <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
-  </CopyToClipboard>
-  <SyntaxHighlighter language="tsx">
-    {`
+          onCopy={handleCopy}
+        >
+          <button className="copyButton">{copied ? "Copied!" : "Copy"}</button>
+        </CopyToClipboard>
+        <SyntaxHighlighter language="tsx">
+          {`
 import DecimalInput from '@components/Input/DecimalInput';
 
 function FullExample() {
@@ -1285,8 +1406,8 @@ function FullExample() {
 
 export default FullExample;
     `}
-  </SyntaxHighlighter>
-</div>
+        </SyntaxHighlighter>
+      </div>
     </div>
   );
 };

--- a/src/components/CodeBox.tsx
+++ b/src/components/CodeBox.tsx
@@ -1,0 +1,33 @@
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { CopyToClipboard } from "react-copy-to-clipboard";
+
+interface CodeBoxProps {
+  code: string;
+  copyText: string;
+  language: string;
+  index: number;
+  copied: { [key: number]: boolean };
+  handleCopy: (index: number) => void;
+}
+
+const CodeBox: React.FC<CodeBoxProps> = ({
+  code,
+  copyText,
+  language,
+  index,
+  copied,
+  handleCopy,
+}) => {
+  return (
+    <div className="relative">
+      <CopyToClipboard text={copyText} onCopy={() => handleCopy(index)}>
+        <button className="copyButton">
+          {copied[index] ? "Copied!" : "Copy"}
+        </button>
+      </CopyToClipboard>
+      <SyntaxHighlighter language={language}>{code}</SyntaxHighlighter>
+    </div>
+  );
+};
+
+export default CodeBox;


### PR DESCRIPTION
## 🛰️ Issue Number
 - closed: #166 
## 🪐 작업 내용
 copyButton 수정 및 copybox 컴포넌트 분리 및 doc 수정
<img width="522" alt="스크린샷 2024-08-27 22 38 08" src="https://github.com/user-attachments/assets/b36860a5-123f-480b-ab65-0c8422bc29ec">
<img width="437" alt="스크린샷 2024-08-27 22 39 04" src="https://github.com/user-attachments/assets/6d070cd7-b75b-4f2f-9e7a-4b1f888421c8">

copy상태에 인덱스를 부여하여 독립적으로 상태가 변경되게 수정했습니다!

##코드가 너무 복잡하고 길어서 이제서야 CodeBox컴포넌트를 만들었는데 임포트해서 쓰시면 편리합니당
<img width="447" alt="스크린샷 2024-08-27 22 37 19" src="https://github.com/user-attachments/assets/f62e43fd-46fd-4c03-8fee-3e05263ada40">

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 📷스크린샷
PR과 관련된 UI 변경사항이 있다면, 스크린샷을 포함시키세요.

![스크린샷](이미지_URL)
