### PR TITLE
feat: ImageUpload의 Icon 추가

### DIFF
--- a/src/app/(page)/dw/dw4/page.tsx
+++ b/src/app/(page)/dw/dw4/page.tsx
@@ -57,6 +57,11 @@ const Dw4 = () => {
       </div>
       <div>
         <ImageUpload onImageSelect={onSelectImageHandler} />
+        <ImageUpload icon="icon-image" iconPosition="left" text="left" />
+        <ImageUpload icon="icon-image" iconPosition="right" text="right" />
+        <ImageUpload icon="icon-image" iconPosition="top" text="top" />
+        <ImageUpload icon="icon-image" iconPosition="bottom" text="bottom" />
+        <ImageUpload icon="icon-image" iconColor="blue" text="blue" />
       </div>
     </>
   );

--- a/src/app/(page)/dw/dw4/page.tsx
+++ b/src/app/(page)/dw/dw4/page.tsx
@@ -63,6 +63,11 @@ const Dw4 = () => {
         <ImageUpload icon="icon-image" iconPosition="bottom" text="bottom" />
         <ImageUpload icon="icon-image" iconColor="blue" text="blue" />
       </div>
+      <div>
+        <ImageUpload icon="icon-camera" iconSize="small" />
+        <ImageUpload icon="icon-camera" iconSize="medium" />
+        <ImageUpload icon="icon-camera" iconSize="large" />
+      </div>
     </>
   );
 };

--- a/src/components/ImageUpload/Imageupload.tsx
+++ b/src/components/ImageUpload/Imageupload.tsx
@@ -3,6 +3,8 @@ import React, { useState, ChangeEvent } from "react";
 import { Color16, Size } from "types/type";
 import { v4 as uuidv4 } from "uuid";
 import { useEffect } from "react";
+import { IconName } from "@components/Icon/Icon";
+import Icon from "@components/Icon/Icon";
 type ImageUploadProps = {
   shape?: "rectangle" | "circle";
   size?: Size;
@@ -10,6 +12,10 @@ type ImageUploadProps = {
   text?: string;
   variant?: "solid" | "border";
   className?: string;
+  icon?: IconName;
+  iconSize?: "small" | "medium" | "large";
+  iconColor?: string;
+  iconPosition?: "left" | "right" | "top" | "bottom";
   onImageSelect?: (data: string | null) => void;
 };
 
@@ -17,9 +23,13 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
   shape = "circle",
   size = "medium",
   color = "basic",
-  text = "+ Upload",
+  text,
   variant = "solid",
   className,
+  icon = "icon-image",
+  iconSize = "medium",
+  iconColor = "currentColor",
+  iconPosition = "top",
   onImageSelect,
 }) => {
   const [previewImage, setPreviewImage] = useState<string | null>(null);
@@ -102,6 +112,17 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
     }
   };
 
+  const imageuploadIconSIze =
+    iconSize === "small" ? 16 : iconSize === "medium" ? 24 : 32;
+
+  const imageUploadIconPosition =
+    iconPosition === "top"
+      ? "flex-col"
+      : iconPosition === "bottom"
+        ? "flex-col-reverse"
+        : iconPosition === "left"
+          ? "flex-row"
+          : "flex-row-reverse";
   return (
     <>
       <input
@@ -122,8 +143,17 @@ const ImageUpload: React.FC<ImageUploadProps> = ({
             className={`flex h-full w-full object-cover ${shape === "rectangle" ? "rounded-lg" : "rounded-full"}`}
           />
         ) : (
-          <div className="flex h-full w-full items-center justify-center">
-            <div className="align-middle">{text}</div>
+          <div
+            className={`flex h-full w-full items-center justify-center ${imageUploadIconPosition}`}
+          >
+            {icon && (
+              <Icon name={icon} size={imageuploadIconSIze} color={iconColor} />
+            )}
+            {text && (
+              <span className="max-w-full whitespace-normal break-words">
+                {text}
+              </span>
+            )}
           </div>
         )}
       </label>


### PR DESCRIPTION
## 🛰️ Issue Number
 - closed: #337 
## 🪐 작업 내용
버튼 처럼 ImageUpload에 아이콘 사이즈와 컬러, 위치 등을 할수 있도록 props 설정 
```
  icon?: IconName;
  iconSize?: "small" | "medium" | "large";
  iconColor?: string;
  iconPosition?: "left" | "right" | "top" | "bottom";
```
![image](https://github.com/user-attachments/assets/e44d462c-0c47-4781-9de7-d10ea759b545)

text 대신 아이콘이 기본값, 없을경우 가운데 크게 나오는 형태 
## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?

## 📷스크린샷
PR과 관련된 UI 변경사항이 있다면, 스크린샷을 포함시키세요.

위에 첨부 
